### PR TITLE
Reset Twitch.tv as resumable media

### DIFF
--- a/lua/playx/providers/twitch.tv.lua
+++ b/lua/playx/providers/twitch.tv.lua
@@ -55,7 +55,7 @@ function TwitchTV.GetPlayer(url, useJW)
 	        return {
 	            ["Handler"] = "IFrame",
 	            ["URI"] =  fullURL,
-	            ["ResumeSupported"] = false,
+	            ["ResumeSupported"] = true,
 	            ["LowFramerate"] = false,
 	            ["MetadataFunc"] = function(callback, failCallback)
 	                TwitchTV.QueryMetadata(fullURL, callback, failCallback)


### PR DESCRIPTION
Not sure why this was changed, but someone who joined while a stream was playing didn't see it until I re-opened the media.  Switched this back and it's working flawlessly.