### PR TITLE
Fixes click on interfaces pausing video

### DIFF
--- a/lua/entities/gmod_playx/cl_init.lua
+++ b/lua/entities/gmod_playx/cl_init.lua
@@ -172,7 +172,7 @@ end
 
 function ENT:CreateBrowser()
     self.Browser = vgui.Create("PlayXHTML")
-    self.Browser:SetMouseInputEnabled(true)        
+    self.Browser:SetMouseInputEnabled(false)        
     self.Browser:SetSize(self.HTMLWidth, self.HTMLHeight)
     self.Browser:SetPaintedManually(true)
     self.Browser:SetVerticalScrollbarEnabled(false)


### PR DESCRIPTION
This fixes the bug which pauses the video if you click on garrysmod interfaces like the scoreboard and tabs.
#106 