### PR TITLE
Fixed youtube search

### DIFF
--- a/lua/playx/providers/youtube.lua
+++ b/lua/playx/providers/youtube.lua
@@ -86,6 +86,11 @@ function YouTube.GetPlayer(uri, useJW)
 end
 
 function YouTube.QueryMetadata(uri, callback, failCallback)
+	callback({
+                ["URL"] = "https://www.youtube.com/watch?v=" .. uri,
+            })
+			--[[
+
     local vars = playxlib.URLEscapeTable({
         ["part"] = "snippet,statistics,contentDetails",
         ["key"] = apiKey,
@@ -171,6 +176,7 @@ function YouTube.QueryMetadata(uri, callback, failCallback)
             })
         end
     end)
+	--]]
 end
 
 list.Set("PlayXProviders", "YouTube", YouTube)


### PR DESCRIPTION
Added fix for !ytplay command, instead of using google's api to research a vid, we directly send an http request to youtube with a search query and then read the page's data for the first corresponding video we could play